### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,10 +14,10 @@ begin	KEYWORD2
 mode	KEYWORD2
 setOversampling	KEYWORD2
 getOversampling	KEYWORD2
-iirFilter KEYWORD2
-inactiveTime KEYWORD2
-measurementTime KEYWORD2
-getSensorData KEYWORD2
+iirFilter	KEYWORD2
+inactiveTime	KEYWORD2
+measurementTime	KEYWORD2
+getSensorData	KEYWORD2
 
 ########################
 # Constants (LITERAL1) #


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords