### PR TITLE
Initialize SPI params to 0

### DIFF
--- a/src/MAX31855.h
+++ b/src/MAX31855.h
@@ -93,8 +93,8 @@ class MAX31855_Class {
   uint8_t fault() const;                      // return any fault codes detected
  private:
   int32_t readRaw();          // Read 32 bits data from MAX31855
-  uint8_t _cs, _miso, _sck;   ///< Store SPI pin values
-  uint8_t _errorCode;         ///< MAX31855 fault code bits
+  uint8_t _cs = 0, _miso = 0, _sck = 0;   ///< Store SPI pin values
+  uint8_t _errorCode = 0;         ///< MAX31855 fault code bits
   bool    _reversed = false;  ///< Set to true if contacts reversed
 };                            // of MAX31855 class definition
 #endif


### PR DESCRIPTION
# Description
This fixes the class sometimes using soft SPI and incorrect pins, making it not work, when it should use hard SPI.

## Type of change

_Please delete options that are not relevant._

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Ran on a STM32G030C8T6, connected to two MAX31855.

**Test Configuration**:
```
platform = ststm32
board = generic_stm32g030c8t
framework = arduino
```

# Checklist:

- [ ] The changes made link back to an existing issue number
- [X] I have performed a self-review of my own code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] The code adheres to the [Google Style Guide](https://google.github.io/styleguide/cppguide.html)
- [X] The code follows the existing program documentation style using [doxygen](http://www.doxygen.nl/)
- [X] I have made corresponding changes to the documentation / Wiki Page(s)
- [X] My changes generate no new warnings
- [ ] The automated TRAVIS-CI run has a status of "passed"
- [X] I have checked potential areas where regression errors could occur and have found no issues
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

[![Zanshin Logo](https://zanduino.github.io/Images/zanshinkanjitiny.gif) <img src="https://zanduino.github.io/Images/zanshintext.gif" width="75"/>](https://zanduino.github.io)
